### PR TITLE
Suppress stacktrace on non-zero exit code

### DIFF
--- a/ansible_toolbox/cmd/eval.py
+++ b/ansible_toolbox/cmd/eval.py
@@ -31,7 +31,7 @@ class App (BaseApp):
 
             cmd = ['ansible-playbook', tmplfd.name]
             cmd.extend(self.build_command_line(args))
-            subprocess.check_call(cmd)
+            subprocess.call(cmd)
 
 
 def main():

--- a/ansible_toolbox/cmd/role.py
+++ b/ansible_toolbox/cmd/role.py
@@ -30,7 +30,7 @@ class App (BaseApp):
 
             cmd = ['ansible-playbook', fd.name]
             cmd.extend(self.build_command_line(args))
-            subprocess.check_call(cmd)
+            subprocess.call(cmd)
 
 
 def main():

--- a/ansible_toolbox/cmd/task.py
+++ b/ansible_toolbox/cmd/task.py
@@ -30,7 +30,7 @@ class App (BaseApp):
 
             cmd = ['ansible-playbook', fd.name]
             cmd.extend(self.build_command_line(args))
-            subprocess.check_call(cmd)
+            subprocess.call(cmd)
 
 
 def main():


### PR DESCRIPTION
Ansible may return a non-zero exit code if a role or tasklist fails. Since this is not a scripting error it should not produce a stacktrace.