### PR TITLE
Disable Ansible retry files

### DIFF
--- a/ansible_toolbox/base.py
+++ b/ansible_toolbox/base.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import jinja2
 import jinja2.loaders
@@ -6,6 +7,7 @@ class BaseApp (object):
     def __init__(self):
         self._env = jinja2.Environment(
             loader=jinja2.loaders.PackageLoader('ansible_toolbox', 'templates'))
+        os.environ["ANSIBLE_RETRY_FILES_ENABLED"] = "False"
 
     def get_template(self, template):
         return self._env.get_template(template)


### PR DESCRIPTION
Since ansible-toolbox's main use case is for ad-hoc auto-generated playbooks, and since ansible-toolbox's retry files are named after the (randomly-generated) temporary playbook names, retry files are not useful in this context.

Still, there may be a reason why retry files are enabled in general, so this change overrides retry file generation at playbook creation time via a temporary environment variable.